### PR TITLE
Account enrollment

### DIFF
--- a/lib/accounts-templates-core.js
+++ b/lib/accounts-templates-core.js
@@ -311,7 +311,6 @@ if (Meteor.isClient) {
         "sgup", // Sign Up
         "fpwd", // Forgot Password
         "cpwd", // Change Password
-        "enro", // Enroll
     ];
 
     // Reactivity Stuff


### PR DESCRIPTION
Basically, the account enrollment is an alias of the reset password feature except with a different url `/enroll-account/:token`
