### PR TITLE
Checking typeof error.details before settings fields errors when signing in fail

### DIFF
--- a/lib/accounts-templates-core.js
+++ b/lib/accounts-templates-core.js
@@ -729,12 +729,8 @@ if (Meteor.isClient) {
                             for (var fieldName in fieldErrors)
                                 AccountsTemplates.setFieldError(fieldName, fieldErrors[fieldName]);
                         }
-                        // If error.details is a string, just set it as the overall error:
-                        // this is useful for Accounts.validateNewUser which only allow customization of the details property
-                        if(typeof(error.details === 'string'))
-                            AccountsTemplates.setFieldError('overall', error.details);                            
-                        else 
-                            AccountsTemplates.setFieldError('overall', error.reason);                            
+                        
+                        AccountsTemplates.setFieldError('overall', error.reason);                            
                     } else {
                         // FIXME: deal with verification email
                         AccountsTemplates.setFieldError('overall', false);


### PR DESCRIPTION
This avoid some undefined errors when calling AccountsTemplates.setFieldError
