### PR TITLE
Fix enroll url

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -330,7 +330,7 @@ AT.prototype.setupRoutes = function() {
         }
         // Configures enrol account email link
         if ('enrolAccount' in AccountsTemplates._routes){
-            Accounts.urls.enrolAccount = function(token){
+            Accounts.urls.enrollAccount = function(token){
                 var path = AccountsTemplates._routes['enrolAccount'].path;
                 return Meteor.absoluteUrl(path + '/' + token);
             };


### PR DESCRIPTION
There was a typo for overriding the `Accounts.urls.enrollAccount` (It must have two "L" instead of one). See :

https://github.com/meteor/meteor/blob/devel/packages/accounts-base/url_server.js
