### PR TITLE
Error message consistency and space after ":"

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -459,10 +459,10 @@ AT.prototype.validateField = function(fieldId, value, strict) {
     var valueLength = value.length;
     var minLength = field.minLength;
     if (minLength && valueLength < minLength)
-        return "Minimum Required Length: " + minLength;
+        return "Minimum required length: " + minLength;
     var maxLength = field.maxLength;
     if (maxLength && valueLength > maxLength)
-        return "Maximum Allowed Length: " + maxLength;
+        return "Maximum allowed length: " + maxLength;
     if (field.re && valueLength && !value.match(field.re))
         return field.errStr;
     if (field.func && valueLength && !field.func(value))


### PR DESCRIPTION
Added space after ":" for minimum and maximum length error messages. Just looks nicer.
