### PR TITLE
Update ensureSignedIn

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -159,7 +159,7 @@ AT.prototype.clearState = function() {
 
 AT.prototype.ensureSignedIn = function() {
     if (!Meteor.user()) {
-        AccountsTemplates.setPrevPath(Router.current().route.url);
+        AccountsTemplates.setPrevPath(Router.current().url);
         AccountsTemplates.setState(AccountsTemplates.options.defaultState, function(){
             var err = T9n.get(AccountsTemplates.texts.errors.mustBeLoggedIn, markIfMissing=false);
             AccountsTemplates.state.form.set("error", [err]);


### PR DESCRIPTION
`Router.current().route.path()` returned null in route with parameters. 
`Router.current().route._path` works fine.
