### PR TITLE
Avoids a race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,25 +1319,29 @@ Normally, if you have not configured a social account with, e.g.,
 ```javascript
 // Set up login services
 Meteor.startup(function() {
-    // Remove configuration entries in case service is already configured
-    ServiceConfiguration.configurations.remove({$or: [
-        {service: "facebook"},
-        {service: "github"}
-    ]});
-
     // Add Facebook configuration entry
-    ServiceConfiguration.configurations.insert({
-        "service": "facebook",
-        "appId": "XXXXXXXXXXXXXXX",
-        "secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    });
+    ServiceConfiguration.configurations.update(
+      { "service": "facebook" },
+      {
+        $set: {
+          "appId": "XXXXXXXXXXXXXXX",
+          "secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        }
+      },
+      { upsert: true }
+    );
 
     // Add GitHub configuration entry
-    ServiceConfiguration.configurations.insert({
-        "service": "github",
-        "clientId": "XXXXXXXXXXXXXXXXXXXX",
-        "secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    });
+    ServiceConfiguration.configurations.update(
+      { "service": "github" },
+      {
+        $set: {
+          "clientId": "XXXXXXXXXXXXXXXXXXXX",
+          "secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        }
+      },
+      { upsert: true }
+    );
 });
 ```
 


### PR DESCRIPTION
Doing a remove and then an insert means that there is a period of time when there isn't a configuration entry. MongoDB does not have transactions, atomic upserts are used instead. If there are multiple meteor servers backed by one MongoDB database, this race condition could cause user-visible issues.
