### PR TITLE
Place email verification logic inside onRun Hook (issue #173)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -572,11 +572,8 @@ AT.prototype.setupRoutes = function() {
                     name: name,
                     template: template,
                     layoutTemplate: layoutTemplate,
-                    onBeforeAction: function() {
+                    onRun: function() {
                         AccountsTemplates.setState(route);
-                        this.next();
-                    },
-                    onAfterAction: function() {
                         AccountsTemplates.setDisabled(true);
                         var token = this.params.paramToken;
                         Accounts.verifyEmail(token, function(error){
@@ -585,6 +582,8 @@ AT.prototype.setupRoutes = function() {
                                 AccountsTemplates.state.form.set("result", AccountsTemplates.texts.info.emailVerified);
                             });
                         });
+
+                        this.next();
                     },
                     onStop: function() {
                         AccountsTemplates.clearState();


### PR DESCRIPTION
The onAfterHook can be twice if there are subscriptions on the global RouteController: once before the subscriptions are ready and once after. This was causing the verification code to be sent twice, resulting in an error from the second call stating that the code had expired.