### PR TITLE
Fix "expired link" error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -452,8 +452,16 @@ AT.prototype.postSubmitRedirect = function(route){
                 Router.go(nextPath);
         }else{
             var previousPath = AccountsTemplates.getPrevPath();
-            if (previousPath)
-                Router.go(previousPath);
+            if (previousPath) {
+
+                // Never redirect back to /verify-email as this well cause a 2nd token
+                // verification which will cause an error to be displayed to the user.
+
+                verifyEmailPath = AccountsTemplates.routes["verifyEmail"].path.substr(1);
+                url = Meteor.absoluteUrl(verifyEmailPath + "/");
+                if (previousPath.slice(0, url.length).toString() != url)
+                    Router.go(previousPath);
+            }
             else{
                 var homeRoutePath = AccountsTemplates.options.homeRoutePath;
                 if (homeRoutePath)


### PR DESCRIPTION
When an email address is verified a message is displayed and time-out set to take the user back to the previous route.

If the user changes route before this timeout then, when the timeout fires, it will try to redirect back to /verify-email. This causes a 2nd token verification and thus generates an "Expired" message.

We should never redirect to the /verify-email route. This fixes that.