### PR TITLE
prevented default browser behaviour from interfering with Router.go

### DIFF
--- a/lib/templates_helpers/at_nav_button.js
+++ b/lib/templates_helpers/at_nav_button.js
@@ -10,6 +10,7 @@ AT.prototype.atNavButtonEvents = {
         if (Meteor.user())
             AccountsTemplates.logout();
         else
+            event.preventDefault();
             Router.go(AccountsTemplates.getRouteName('signIn'));
     },
 };

--- a/lib/templates_helpers/at_nav_button.js
+++ b/lib/templates_helpers/at_nav_button.js
@@ -7,10 +7,10 @@ AT.prototype.atNavButtonHelpers = {
 
 AT.prototype.atNavButtonEvents = {
     'click #at-nav-button': function(event){
+        event.preventDefault();
         if (Meteor.user())
             AccountsTemplates.logout();
         else
-            event.preventDefault();
             Router.go(AccountsTemplates.getRouteName('signIn'));
     },
 };


### PR DESCRIPTION
I forgot to add this in from my last pull request. Router.go was having trouble redirecting my page because the browser would interfere.