### PR TITLE
Correction in custom validation example of Guide.md

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -744,7 +744,7 @@ AccountsTemplates.addField({
     _id: 'name',
     type: 'text',
     displayName: "Name",
-    func: function(value){return value === 'Full Name';},
+    func: function(value){return value !== 'Full Name';},
     errStr: 'Only "Full Name" allowed!',
 });
 ```


### PR DESCRIPTION
If only Full name is allowed then error should be thrown when the value is not equal to 'Full name'.