### PR TITLE
Flow router integration

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -111,59 +111,41 @@ AT.prototype.clearMessage = function() {
     form.set("message", null);
 };
 
-var ensureSignedIn = function() {
-  if (!Meteor.userId()) {
-      Tracker.nonreactive(function () {
-        AccountsTemplates.setPrevPath(Router.current().url);
-      });
-      AccountsTemplates.setState(AccountsTemplates.options.defaultState, function(){
-          var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
-          AccountsTemplates.state.form.set("error", [err]);
-      });
-      AccountsTemplates.avoidRedirect = true;
-      // render the login template but keep the url in the browser the same
+// var ensureSignedIn = function() {
+//   if (!Meteor.userId()) {
+//       Tracker.nonreactive(function () {
+//         AccountsTemplates.setPrevPath(FlowRouter.current().path);
+//       });
+//       AccountsTemplates.setState(AccountsTemplates.options.defaultState, function(){
+//           var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
+//           AccountsTemplates.state.form.set("error", [err]);
+//       });
+//       AccountsTemplates.avoidRedirect = true;
+//       // render the login template but keep the url in the browser the same
 
-      var options = AccountsTemplates.routes["ensureSignedIn"];
+//       var options = AccountsTemplates.routes["ensureSignedIn"];
 
-      // Determines the template to be rendered in case no specific one was configured for ensureSignedIn
-      var signInRouteTemplate = AccountsTemplates.routes.signIn && AccountsTemplates.routes.signIn.template;
-      var template = (options && options.template) || signInRouteTemplate || "fullPageAtForm";
+//       // Determines the template to be rendered in case no specific one was configured for ensureSignedIn
+//       var signInRouteTemplate = AccountsTemplates.routes.signIn && AccountsTemplates.routes.signIn.template;
+//       var template = (options && options.template) || signInRouteTemplate || "fullPageAtForm";
 
-      // Determines the layout to be used in case no specific one was configured for ensureSignedIn
-      var defaultLayout = AccountsTemplates.options.defaultLayout || Router.options.layoutTemplate;
-      var layoutTemplate = (options && options.layoutTemplate) || defaultLayout;
+//       // Determines the layout to be used in case no specific one was configured for ensureSignedIn
+//       var defaultLayout = AccountsTemplates.options.defaultLayout;
+//       var layoutTemplate = (options && options.layoutTemplate) || defaultLayout;
 
-      this.layout(layoutTemplate);
-      this.render(template);
-      this.renderRegions();
-  } else {
-      this.next();
-  }
-};
+      
+//       renderLayout[contentRange] = template;
+//       FlowLayout.render(layoutTemplate, renderLayout);
+//   } else {
+//       this.next();
+//   }
+// };
 
-AT.prototype.ensureSignedIn = function() {
-  console.warn(
-    "[UserAccounts] AccountsTemplates.ensureSignedIn will be deprecated soon, please use the plugin version\n" +
-    "               see https://github.com/meteor-useraccounts/core/blob/master/Guide.md#content-protection"
-  );
-  ensureSignedIn.call(this);
-};
-
-
-Iron.Router.plugins.ensureSignedIn = function (router, options) {
-  // this loading plugin just creates an onBeforeAction hook
-  router.onRun(function(){
-    if (Meteor.loggingIn()) {
-        this.renderRegions();
-    } else {
-        this.next();
-    }
-  }, options);
-
-  router.onBeforeAction(
-    ensureSignedIn,
-    options
-  );
+AT.prototype.ensureSignedIn = function(path, next) {
+  // copied from flow-router docs
+  // this works only because the use of Fast Render
+  var redirectPath = (!Meteor.userId())? "/sign-in" : null;
+  next(redirectPath);
 };
 
 
@@ -424,26 +406,6 @@ AT.prototype._init = function() {
     // Known routes are used to filter out previous path for redirects...
     this.knownRoutes = _.pluck(_.values(this.routes), "path");
 
-    // Stores previous path on path change...
-    Router.onStop(function() {
-        Tracker.nonreactive(function () {
-            var currentPath = Router.current().url;
-            var currentPathClean = currentPath.replace(/^\/+|\/+$/gm,'')
-            var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(path){
-              if (!path) {
-                return false;
-              }
-              path = path.replace(/^\/+|\/+$/gm,'');
-              var known = RegExp(path).test(currentPathClean)
-              return known;
-            });
-            if (!_.some(isKnownRoute)) {
-                AccountsTemplates.setPrevPath(currentPath);
-            }
-            AccountsTemplates.avoidRedirect = false;
-        });
-    });
-
     // Sets up configured routes
     AccountsTemplates.setupRoutes();
 
@@ -451,15 +413,30 @@ AT.prototype._init = function() {
     this._initialized = true;
 };
 
+// Stores previous path on path change...
+FlowRouter.middleware(function(currentPath, next) {
+    var isKnownRoute = _.map(AccountsTemplates.knownRoutes, function(path){
+      if (!path) {
+        return false;
+      }
+      var known = RegExp(path).test(currentPath)
+      return known;
+    });
+    if (!_.some(isKnownRoute)) {
+        AccountsTemplates.setPrevPath(currentPath);
+    }
+    next();
+})
+
 AT.prototype.linkClick = function(route){
     if (AccountsTemplates.disabled())
         return;
     var path = AccountsTemplates.getRoutePath(route);
-    if (path === "#" || AccountsTemplates.avoidRedirect || path === Router.current().route.path())
+    if (path === "#" || AccountsTemplates.avoidRedirect || path === FlowRouter.current().path)
         AccountsTemplates.setState(route);
     else
         Meteor.defer(function(){
-            Router.go(AccountsTemplates.getRouteName(route));
+            FlowRouter.go(path);
         });
 };
 
@@ -470,7 +447,7 @@ AT.prototype.logout = function(){
         if (onLogoutHook)
           onLogoutHook();
         else if (homeRoutePath)
-            Router.go(homeRoutePath);
+            FlowRouter.go(homeRoutePath);
     });
 };
 
@@ -483,15 +460,15 @@ AT.prototype.postSubmitRedirect = function(route){
             if (_.isFunction(nextPath))
                 nextPath();
             else
-                Router.go(nextPath);
+                FlowRouter.go(nextPath);
         }else{
             var previousPath = AccountsTemplates.getPrevPath();
             if (previousPath)
-                Router.go(previousPath);
+                FlowRouter.go(previousPath);
             else{
                 var homeRoutePath = AccountsTemplates.options.homeRoutePath;
                 if (homeRoutePath)
-                    Router.go(homeRoutePath);
+                    FlowRouter.go(homeRoutePath);
             }
         }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -111,41 +111,46 @@ AT.prototype.clearMessage = function() {
     form.set("message", null);
 };
 
-// var ensureSignedIn = function() {
-//   if (!Meteor.userId()) {
-//       Tracker.nonreactive(function () {
-//         AccountsTemplates.setPrevPath(FlowRouter.current().path);
-//       });
-//       AccountsTemplates.setState(AccountsTemplates.options.defaultState, function(){
-//           var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
-//           AccountsTemplates.state.form.set("error", [err]);
-//       });
-//       AccountsTemplates.avoidRedirect = true;
-//       // render the login template but keep the url in the browser the same
+var ensureSignedIn = function(path, next) {
+  if (!Meteor.userId()) {
+      // Tracker.nonreactive(function () {
+        AccountsTemplates.setPrevPath(path);
+      // });
+      AccountsTemplates.setState(AccountsTemplates.options.defaultState, function(){
+          var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
+          AccountsTemplates.state.form.set("error", [err]);
+      });
 
-//       var options = AccountsTemplates.routes["ensureSignedIn"];
+      // after the signIn is submitted
+      AccountsTemplates.avoidRedirect = true;
+      // since flow-router doesn't reevaluate (->rerender) reatively we have to do this
+      AccountsTemplates.rerenderCurrentPath = true;
+      // render the login template but keep the url in the browser the same
 
-//       // Determines the template to be rendered in case no specific one was configured for ensureSignedIn
-//       var signInRouteTemplate = AccountsTemplates.routes.signIn && AccountsTemplates.routes.signIn.template;
-//       var template = (options && options.template) || signInRouteTemplate || "fullPageAtForm";
+      var options = AccountsTemplates.routes["ensureSignedIn"];
 
-//       // Determines the layout to be used in case no specific one was configured for ensureSignedIn
-//       var defaultLayout = AccountsTemplates.options.defaultLayout;
-//       var layoutTemplate = (options && options.layoutTemplate) || defaultLayout;
+      // Determines the template to be rendered in case no specific one was configured for ensureSignedIn
+      var signInRouteTemplate = AccountsTemplates.routes.signIn && AccountsTemplates.routes.signIn.template;
+      var template = (options && options.template) || signInRouteTemplate || "fullPageAtForm";
 
+      // Determines the layout to be used in case no specific one was configured for ensureSignedIn
+      var defaultLayout = AccountsTemplates.options.defaultLayout;
+      var defaultLayoutRegions = AccountsTemplates.options.defaultLayoutRegions;
+      var defaultContentRegion = AccountsTemplates.options.defaultContentRegion;
+
+      var layoutTemplate = (options && options.layoutTemplate) || defaultLayout;
+      var layoutRegions = (options && options.renderLayout) || defaultLayoutRegions;
+      var contentRegion = (options && options.contentRegion) || defaultContentRegion;
       
-//       renderLayout[contentRange] = template;
-//       FlowLayout.render(layoutTemplate, renderLayout);
-//   } else {
-//       this.next();
-//   }
-// };
+      layoutRegions[contentRegion] = template;
+      FlowLayout.render(layoutTemplate, layoutRegions);
+  } else {
+      next();
+  }
+};
 
 AT.prototype.ensureSignedIn = function(path, next) {
-  // copied from flow-router docs
-  // this works only because the use of Fast Render
-  var redirectPath = (!Meteor.userId())? "/sign-in" : null;
-  next(redirectPath);
+  ensureSignedIn(path, next);
 };
 
 
@@ -452,8 +457,13 @@ AT.prototype.logout = function(){
 };
 
 AT.prototype.postSubmitRedirect = function(route){
-    if (AccountsTemplates.avoidRedirect)
+    if (AccountsTemplates.avoidRedirect){
         AccountsTemplates.avoidRedirect = false;
+
+        if(AccountsTemplates.rerenderCurrentPath) {
+            FlowRouter.go(FlowRouter.current().path);
+        }
+    }
     else{
         var nextPath = AccountsTemplates.routes[route] && AccountsTemplates.routes[route].redirect;
         if (nextPath){

--- a/lib/core.js
+++ b/lib/core.js
@@ -90,6 +90,8 @@ CONFIG_PAT = {
 
     // Appearance
     defaultLayout: Match.Optional(String),
+    defaultLayoutRegions: Match.Optional(Object),
+    defaultContentRegion: Match.Optional(String),
     hideSignInLink: Match.Optional(Boolean),
     hideSignUpLink: Match.Optional(Boolean),
     showAddRemoveServices: Match.Optional(Boolean),
@@ -635,6 +637,8 @@ AT.prototype.setupRoutes = function() {
 
     // Determines the default layout to be used in case no specific one is specified for single routes
     var defaultLayout = AccountsTemplates.options.defaultLayout;
+    var defaultLayoutRegions = AccountsTemplates.options.defaultLayoutRegions;
+    var defaultContentRegion = AccountsTemplates.options.defaultContentRegion;
 
     _.each(AccountsTemplates.routes, function(options, route){
         if (route === "ensureSignedIn")
@@ -654,8 +658,8 @@ AT.prototype.setupRoutes = function() {
         var path = options.path; // Default provided...
         var template = options.template || "fullPageAtForm";
         var layoutTemplate = options.layoutTemplate || defaultLayout;
-        var renderLayout = options.renderLayout || {};
-        var contentRange = options.contentRange;
+        var layoutRegions = options.layoutRegions || defaultLayoutRegions;
+        var contentRegion = options.contentRegion || defaultContentRegion;
 
         // Possibly adds token parameter
         if (_.contains(["enrollAccount", "resetPwd", "verifyEmail"], route)){
@@ -669,8 +673,8 @@ AT.prototype.setupRoutes = function() {
                         next();
                     }],
                     action: function(params) {
-                        renderLayout[contentRange] = template;
-                        FlowLayout.render(layoutTemplate, renderLayout);
+                        layoutRegions[contentRegion] = template;
+                        FlowLayout.render(layoutTemplate, layoutRegions);
 
                         var token = params.paramToken;
                         Accounts.verifyEmail(token, function(error){
@@ -688,8 +692,8 @@ AT.prototype.setupRoutes = function() {
                         next();
                     }],
                     action: function(params) {
-                        renderLayout[contentRange] = template;
-                        FlowLayout.render(layoutTemplate, renderLayout);
+                        layoutRegions[contentRegion] = template;
+                        FlowLayout.render(layoutTemplate, layoutRegions);
                     }
                 });
         }
@@ -714,8 +718,8 @@ AT.prototype.setupRoutes = function() {
                     }
                 }],
                 action: function() {
-                    renderLayout[contentRange] = template;
-                    FlowLayout.render(layoutTemplate, renderLayout);
+                    layoutRegions[contentRegion] = template;
+                    FlowLayout.render(layoutTemplate, layoutRegions);
                 }
             });
     });

--- a/lib/core.js
+++ b/lib/core.js
@@ -180,6 +180,8 @@ var ROUTE_PAT = {
     path: Match.Optional(String),
     template: Match.Optional(String),
     layoutTemplate: Match.Optional(String),
+    renderLayout: Match.Optional(Object),
+    contentRange: Match.Optional(String),
     redirect: Match.Optional(Match.OneOf(String, Match.Where(_.isFunction))),
 };
 
@@ -632,7 +634,7 @@ AT.prototype.setupRoutes = function() {
     }
 
     // Determines the default layout to be used in case no specific one is specified for single routes
-    var defaultLayout = AccountsTemplates.options.defaultLayout || Router.options.layoutTemplate;
+    var defaultLayout = AccountsTemplates.options.defaultLayout;
 
     _.each(AccountsTemplates.routes, function(options, route){
         if (route === "ensureSignedIn")
@@ -652,57 +654,48 @@ AT.prototype.setupRoutes = function() {
         var path = options.path; // Default provided...
         var template = options.template || "fullPageAtForm";
         var layoutTemplate = options.layoutTemplate || defaultLayout;
+        var renderLayout = options.renderLayout || {};
+        var contentRange = options.contentRange;
 
         // Possibly adds token parameter
         if (_.contains(["enrollAccount", "resetPwd", "verifyEmail"], route)){
             path += "/:paramToken";
             if (route === "verifyEmail")
-                Router.route(path, {
-                    name: name,
-                    template: template,
-                    layoutTemplate: layoutTemplate,
-                    onRun: function() {
+                FlowRouter.route(path, {
+                    middlewares: [function(path, next) {
                         AccountsTemplates.setState(route);
                         AccountsTemplates.setDisabled(true);
-                        var token = this.params.paramToken;
+
+                        next();
+                    }],
+                    action: function(params) {
+                        renderLayout[contentRange] = template;
+                        FlowLayout.render(layoutTemplate, renderLayout);
+
+                        var token = params.paramToken;
                         Accounts.verifyEmail(token, function(error){
                             AccountsTemplates.setDisabled(false);
                             AccountsTemplates.submitCallback(error, route, function(){
                                 AccountsTemplates.state.form.set("result", AccountsTemplates.texts.info.emailVerified);
                             });
                         });
-
-                        this.next();
-                    },
-                    onStop: function() {
-                        AccountsTemplates.clearState();
-                    },
+                    }
                 });
             else
-                Router.route(path, {
-                    name: name,
-                    template: template,
-                    layoutTemplate: layoutTemplate,
-                    onRun: function() {
-                        AccountsTemplates.paramToken = this.params.paramToken;
-                        this.next();
-                    },
-                    onBeforeAction: function() {
+                FlowRouter.route(path, {
+                    middlewares:[function(path, next) {
                         AccountsTemplates.setState(route);
-                        this.next();
-                    },
-                    onStop: function() {
-                        AccountsTemplates.clearState();
-                        AccountsTemplates.paramToken = null;
+                        next();
+                    }],
+                    action: function(params) {
+                        renderLayout[contentRange] = template;
+                        FlowLayout.render(layoutTemplate, renderLayout);
                     }
                 });
         }
         else
-            Router.route(path, {
-                name: name,
-                template: template,
-                layoutTemplate: layoutTemplate,
-                onBeforeAction: function() {
+            FlowRouter.route(path, {
+                middlewares: [function(path, next) {
                     var redirect = false;
                     if (route === 'changePwd') {
                       if (!Meteor.loggingIn() && !Meteor.userId()) {
@@ -714,15 +707,15 @@ AT.prototype.setupRoutes = function() {
                     }
                     if (redirect) {
                         AccountsTemplates.postSubmitRedirect(route);
-                        this.stop();
                     }
                     else {
                         AccountsTemplates.setState(route);
-                        this.next();
+                        next();
                     }
-                },
-                onStop: function() {
-                    AccountsTemplates.clearState();
+                }],
+                action: function() {
+                    renderLayout[contentRange] = template;
+                    FlowLayout.render(layoutTemplate, renderLayout);
                 }
             });
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -147,7 +147,7 @@ AT.prototype._init = function() {
 
 
 // Fake server-side IR plugin to allow for shared routing files
-Iron.Router.plugins.ensureSignedIn = function (router, options) {};
+// Iron.Router.plugins.ensureSignedIn = function (router, options) {};
 
 
 AccountsTemplates = new AT();

--- a/lib/templates_helpers/at_input.js
+++ b/lib/templates_helpers/at_input.js
@@ -1,6 +1,6 @@
 AT.prototype.atInputRendered = function(){
     var fieldId = this.data._id;
-    var inputQueryVal = Router.current().params.query[fieldId];
+    var inputQueryVal = FlowRouter.getQueryParam(fieldId);
     if (inputQueryVal)
         this.$("input#at-field-" + fieldId).val(inputQueryVal);
 };

--- a/lib/templates_helpers/at_pwd_form.js
+++ b/lib/templates_helpers/at_pwd_form.js
@@ -262,7 +262,8 @@ AT.prototype.atPwdFormEvents = {
         // Reset Password / Enroll Account
         //--------------------------------
         if (state === "resetPwd" || state === "enrollAccount") {
-            return Accounts.resetPassword(AccountsTemplates.paramToken, password, function(error) {
+            var paramToken = FlowRouter.getParam('paramToken');
+            return Accounts.resetPassword(paramToken, password, function(error) {
                 AccountsTemplates.submitCallback(error, state, function(){
                     var pwd_field_id;
                     if (state === "resetPwd")

--- a/package.js
+++ b/package.js
@@ -14,7 +14,6 @@ Package.on_use(function(api) {
         "underscore",
         "meteorhacks:flow-router",
         "meteorhacks:flow-layout",
-        "meteorhacks:fast-render",
         "reactive-var",
     ], ["client", "server"]);
 
@@ -32,7 +31,6 @@ Package.on_use(function(api) {
         "softwarerero:accounts-t9n@1.0.6",
         "meteorhacks:flow-router@1.1.1",
         "meteorhacks:flow-layout@1.0.2",
-        "meteorhacks:fast-render@2.3.1",
     ], ["client", "server"]);
 
     api.imply([

--- a/package.js
+++ b/package.js
@@ -12,7 +12,9 @@ Package.on_use(function(api) {
         "accounts-base",
         "check",
         "underscore",
-        "iron:router",
+        "meteorhacks:flow-router",
+        "meteorhacks:flow-layout",
+        "meteorhacks:fast-render",
         "reactive-var",
     ], ["client", "server"]);
 
@@ -28,7 +30,9 @@ Package.on_use(function(api) {
     api.imply([
         "accounts-base",
         "softwarerero:accounts-t9n@1.0.6",
-        "iron:router@1.0.7",
+        "meteorhacks:flow-router@1.1.1",
+        "meteorhacks:flow-layout@1.0.1",
+        "meteorhacks:fast-render@2.3.1",
     ], ["client", "server"]);
 
     api.imply([

--- a/package.js
+++ b/package.js
@@ -31,7 +31,7 @@ Package.on_use(function(api) {
         "accounts-base",
         "softwarerero:accounts-t9n@1.0.6",
         "meteorhacks:flow-router@1.1.1",
-        "meteorhacks:flow-layout@1.0.1",
+        "meteorhacks:flow-layout@1.0.2",
         "meteorhacks:fast-render@2.3.1",
     ], ["client", "server"]);
 


### PR DESCRIPTION
Started working on the flow-router integration. It is not perfect yet, but as far as I (and some others I asked to test) can tell everything is working fine.
One big concern I have is that I completely ignored the `ensureSingedIn` method and used the one that @arunoda shows in the flow-router [docs](https://github.com/meteorhacks/flow-router#middlewares), which seems to do the trick just fine..
One more thing that is not too beautiful right now is that you have to define the FlowLayout and the region where the useraccounts template gets rendered for each route like this:
````javascript
var stdConfig = {
  layoutTemplate: "masterLayout",
  renderLayout: {
      nav: "nav",
      footer: "footer"
  },
  contentRange: "area"
};
AccountsTemplates.configureRoute('signIn', stdConfig);
````
But I think it is an easy one to make that a global config variable on the AT object.
I deployed the materialize version of useraccounts using FlowRouter [here](http://useraccounts-materialize-flow.meteor.com/)
The Demo code is [here](https://github.com/PhilippSpo/useraccounts-materialize-flow).
There is one strange thing still happening: The `postSubmitRedirect` is not working on verifyEmail. haven't looked into this yet.