### PR TITLE
add this.next();

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -136,6 +136,7 @@ var ensureSignedIn = function() {
       this.layout(layoutTemplate);
       this.render(template);
       this.renderRegions();
+      this.next();
   } else {
       this.next();
   }


### PR DESCRIPTION
By adding `this.next();` to the first part of `ensureSignedIn`'s conditional, I was able to stop a recurring issue where loading a route in my `ensureSignedIn` block failed and printed `Route dispatch never rendered. Did you forget to call this.next() in an onBeforeAction?` to the console.