### PR TITLE
allow setError to take in Boolean values

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -114,7 +114,9 @@ if (Meteor.isClient)
 
 if (Meteor.isClient)
     Field.prototype.setError = function(err){
-        check(err, Match.OneOf(String, undefined));
+        check(err, Match.OneOf(String, undefined, Boolean));
+        if (err === false)
+            return this.status.set(false);
         return this.status.set(err || true);
     };
 if (Meteor.isServer)


### PR DESCRIPTION
The note at the end of [this section] (https://github.com/meteor-useraccounts/core/blob/master/Guide.md#custom-validation) in the guide indicates that the state can be a true/false value (the example code above the note passes in a true value to setError). However, if you pass a true or false value to setError it throws an error. Adjusted to allow boolean values.