### PR TITLE
Fixing what i think is a typo

### DIFF
--- a/lib/templates_helpers/at_pwd_form.js
+++ b/lib/templates_helpers/at_pwd_form.js
@@ -30,7 +30,7 @@ AT.prototype.atPwdFormEvents = {
     // Form submit
     "submit #at-pwd-form": function(event, t) {
         event.preventDefault();
-        $("#at-btn").blur();
+        t.$("#at-btn").blur();
 
         AccountsTemplates.setDisabled(true);
 


### PR DESCRIPTION
This $ call without t.$ was causing a "$ is not a function" error in my app.

I think it is a typo since you are not supposed to call $ directly in Meteor i believe.