### PR TITLE
Added extra required step to using flow-router-integration branch

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -1383,8 +1383,9 @@ Enjoy ;-)
 > cd your/project/path
 > mkdir packages && cd packages
 > git clone https://github.com/meteor-useraccounts/core.git
+> cd core
 > git checkout flow-router-integration
-> cd ..
+> cd ../..
 > meteor add useraccounts:<something>
 > meteor
 ```


### PR DESCRIPTION
You need to `cd` into the `core` directory to change the branch of the repository. Just updated the Guide to reflect that.