### PR TITLE
Added check to ATRemoveService method

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -1,6 +1,7 @@
 
 Meteor.methods({
     ATRemoveService: function(service_name){
+        check(service_name, String);
         var userId = this.userId;
         if (userId){
             var user = Meteor.users.findOne(userId);


### PR DESCRIPTION
When removing services from an account, server console displayed an exception `Exception while invoking method 'ATRemoveService' Error: Did not check() all arguments during call to 'ATRemoveService'`.  Noticed that the parameter `service_name` in `ATRemoveService` was not checked. I added the check to make sure that this parameter is a string.  Adding this checked prevented this exception in my local environment and allowed the feature to function as expected.