### PR TITLE
template level content protection

### DIFF
--- a/lib/templates_helpers/ensure_signed_in.html
+++ b/lib/templates_helpers/ensure_signed_in.html
@@ -1,0 +1,12 @@
+<!-- Template level auth -->
+<template name="ensureSignedIn">
+  {{#if currentUser}}
+    {{> Template.dynamic template=template}}
+  {{else}}
+    {{#if auth}}
+      {{> Template.dynamic template=auth}}
+    {{else}}
+      {{> fullPageAtForm}}
+    {{/if}}
+  {{/if}}
+</template>

--- a/lib/templates_helpers/ensure_signed_in.html
+++ b/lib/templates_helpers/ensure_signed_in.html
@@ -1,6 +1,6 @@
 <!-- Template level auth -->
 <template name="ensureSignedIn">
-  {{#if currentUser}}
+  {{#if signedIn}}
     {{> Template.dynamic template=template}}
   {{else}}
     {{#if auth}}

--- a/lib/templates_helpers/ensure_signed_in.js
+++ b/lib/templates_helpers/ensure_signed_in.js
@@ -1,0 +1,15 @@
+
+Template.ensureSignedIn.helpers({
+  signedIn: function () {
+    if (!Meteor.user()) {
+      AccountsTemplates.setState(AccountsTemplates.options.defaultState, function(){
+        var err = AccountsTemplates.texts.errors.mustBeLoggedIn;
+        AccountsTemplates.state.form.set('error', [err]);
+      });
+      return false;
+    } else {
+      AccountsTemplates.clearError();
+      return true;
+    }
+  }
+});

--- a/package.js
+++ b/package.js
@@ -18,6 +18,7 @@ Package.on_use(function(api) {
   api.use([
     'blaze',
     'reactive-dict',
+    'templating'
   ], 'client');
 
   api.use([
@@ -64,6 +65,7 @@ Package.on_use(function(api) {
     'lib/templates_helpers/at_terms_link.js',
     'lib/templates_helpers/at_title.js',
     'lib/templates_helpers/at_message.js',
+    'lib/templates_helpers/ensure_signed_in.html',
     'lib/methods.js',
   ], ['client']);
 

--- a/package.js
+++ b/package.js
@@ -66,6 +66,7 @@ Package.on_use(function(api) {
     'lib/templates_helpers/at_title.js',
     'lib/templates_helpers/at_message.js',
     'lib/templates_helpers/ensure_signed_in.html',
+    'lib/templates_helpers/ensure_signed_in.js',
     'lib/methods.js',
   ], ['client']);
 


### PR DESCRIPTION
If you want to secure a specific template, you could add that template like this:

```handlebars
{{> ensureSignedIn template="myTemplate"}}
```
and that will render the default `fullPageAtForm` template from your chosen User Accounts templates package (bootstrap, materialize, etc).  Once signed in, it'll render `myTemplate` instead of the accounts form.   

If you want to declare a custom sign in template instead of `fullPageAtForm`, you would do this:

```handlebars
{{> ensureSignedIn template="myTemplate" auth="myLoginForm"}}
```
That custom auth template just needs to include `{{> atForm}}` somewhere in it.  The only reason you'd use this optional feature is if you wanted to modify the layout around the `atForm` template (like
`fullPageAtForm` does).
