### PR TITLE
Reset captcha if email already exists

### DIFF
--- a/lib/templates_helpers/at_pwd_form.js
+++ b/lib/templates_helpers/at_pwd_form.js
@@ -199,6 +199,9 @@ AT.prototype.atPwdFormEvents = {
             }
 
             return Meteor.call("ATCreateUserServer", options, function(error){
+                if (error && error.reason === 'Email already exists.') {
+                    grecaptcha.reset();
+                }
                 AccountsTemplates.submitCallback(error, undefined, function(){
                     if (AccountsTemplates.options.sendVerificationEmail && AccountsTemplates.options.enforceEmailVerification){
                         AccountsTemplates.submitCallback(error, state, function () {


### PR DESCRIPTION
Hello!

I found a small bug. If email already exists in a database, captcha does not resets on error. Instead i got "Captcha verification failed" until i refresh page or go to another link and back.