### PR TITLE
translation in getDisplayName

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -69,6 +69,10 @@ if (Meteor.isClient) {
     }
 
     if (!displayName) {
+      displayName = T9n.get(this._id, markIfMissing=false);
+    }
+
+    if (!displayName) {
       displayName = capitalize(this._id);
     }
 


### PR DESCRIPTION
All the language using lowercase id as the t9n key not displayname.
Current problem is the id like email, username will be capitalize to Email, Username, so will be translate failed.
https://github.com/softwarerero/meteor-accounts-t9n/blob/master/t9n/en.coffee
https://github.com/softwarerero/meteor-accounts-t9n/blob/master/t9n/zh_cn.coffee