### PR TITLE
atInput: gather Field object from current data

### DIFF
--- a/lib/templates_helpers/at_input.js
+++ b/lib/templates_helpers/at_input.js
@@ -69,19 +69,21 @@ AT.prototype.atInputHelpers = {
 
 AT.prototype.atInputEvents = {
     "focusin input": function(event, t){
-        this.clearStatus();
+        var field = Template.currentData();
+        field.clearStatus();
     },
     "focusout input, change select": function(event, t){
-        var fieldId = this._id;
-        var rawValue = this.getValue(t);
-        var value = this.fixValue(rawValue);
+        var field = Template.currentData();
+        var fieldId = field._id;
+        var rawValue = field.getValue(t);
+        var value = field.fixValue(rawValue);
         // Possibly updates the input value
         if (value !== rawValue) {
-            this.setValue(t, value);
+            field.setValue(t, value);
         }
 
         // Client-side only validation
-        if (!this.validation)
+        if (!field.validation)
             return;
         var parentData = Template.parentData();
         var state = (parentData && parentData.state) || AccountsTemplates.getState();
@@ -91,31 +93,32 @@ AT.prototype.atInputEvents = {
         // Special case for password confirmation
         if (value && fieldId === "password_again"){
             if (value !== $("#at-field-password").val())
-                return this.setError(AccountsTemplates.texts.errors.pwdMismatch);
+                return field.setError(AccountsTemplates.texts.errors.pwdMismatch);
         }
-        this.validate(value);
+        field.validate(value);
     },
     "keyup input": function(event, t){
+        var field = Template.currentData();
         // Client-side only continuous validation
-        if (!this.continuousValidation)
+        if (!field.continuousValidation)
             return;
         var parentData = Template.parentData();
         var state = (parentData && parentData.state) || AccountsTemplates.getState();
         // No validation during signIn
         if (state === "signIn")
             return;
-        var fieldId = this._id;
-        var rawValue = this.getValue(t);
-        var value = this.fixValue(rawValue);
+        var fieldId = field._id;
+        var rawValue = field.getValue(t);
+        var value = field.fixValue(rawValue);
         // Possibly updates the input value
         if (value !== rawValue) {
-            this.setValue(t, value);
+            field.setValue(t, value);
         }
         // Special case for password confirmation
         if (value && fieldId === "password_again"){
             if (value !== $("#at-field-password").val())
-                return this.setError(AccountsTemplates.texts.errors.pwdMismatch);
+                return field.setError(AccountsTemplates.texts.errors.pwdMismatch);
         }
-        this.validate(value);
+        field.validate(value);
     },
 };


### PR DESCRIPTION
Previously, atInput template assumed 'this' in event handlers
was set to the Field instance the parent template set as our
data context.

This is true for some of the simplest input types like 'text',
'checkbox' and other. However, in the general case this is
not the case.

From Meteor's documentation:

    Event Maps
    ...
    The handler also receives some additional context data
    in this, depending on the context of the current element
    handling the event.

Thus, 'this' in event handlers refer to the context of the
element the event was fired on.

And the 'radio' input type is problematic because the input
element is inside the context provided by a 'each' template.

Meteor's documentation also says:

    Template.currentData()
    ...
    Inside an event handler, returns the data context of the
    template on which this event handler was defined.

And given that handlers are defined at the atInput template what
we really want is Template.currentData().

For instance materialize's at_input.js reads

    Template.atInput.helpers(AccountsTemplates.atInputHelpers);

and so do other styles.

So, as long as that is the case, the field object instance will
be available at Template.currentData(), which is what this patch
proposes to use.

Fixes #473