### PR TITLE
Force all visible fields to be re-validated

### DIFF
--- a/lib/templates_helpers/at_pwd_form.js
+++ b/lib/templates_helpers/at_pwd_form.js
@@ -62,7 +62,7 @@ AT.prototype.atPwdFormEvents = {
             }
 
             // Validates the field value only if current state is not "signIn"
-            if (preValidation && field.getStatus() !== false){
+            if (preValidation){
                 var validationErr = field.validate(value, "strict");
                 if (validationErr) {
                     if (field.negativeValidation)


### PR DESCRIPTION
This fixes https://github.com/meteor-useraccounts/core/issues/695.  Before, fields that previously passed validation didn't have to be re-validated, even if their contents changed, because their `state` would be set to `false` instead of `null`.