### PR TITLE
Handle multiple addresses properly when resending verification mails

### DIFF
--- a/lib/server_methods.js
+++ b/lib/server_methods.js
@@ -131,12 +131,16 @@ Meteor.methods({
       throw new Meteor.Error(403, "User not found");
     }
 
-    try {
-      Accounts.sendVerificationEmail(user._id);
-    } catch (error) {
-      // Handle error when email already verified
-      // https://github.com/dwinston/send-verification-email-bug
-      throw new Meteor.Error(403, "Already verified");
+    // Throw an error if the requested email is already verified
+    for (var i = 0; i < user.emails.length; i++) {
+      if (user.emails[i].address === email) {
+        if (user.emails[i].verified) {
+          throw new Meteor.Error(403, "Already verified");
+        }
+        break;
+      }
     }
+
+    Accounts.sendVerificationEmail(user._id, email);
   },
 });


### PR DESCRIPTION
When sending a verification mail the intended address can be supplied as a second parameter. In the case multiple unverified addresses are available, this will ensure the mail is send to the address the user intended, rather than the first one.

Supplying the email address as a parameter also allows verification mails to be sent to addresses which are already verified. As such, the error handling which turns every possible error that could occur when sending a mail into "Already verified" has been removed, and a separate check to prevent sending verification mails to verified addresses is added.